### PR TITLE
ci: run github action on pull_request 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test_nightly:


### PR DESCRIPTION
right now CI does not run on PRs, instead only on branches pushed to this main remote. We'll need to add the [`pull_request` event](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request) for the CI action to run on PRs ~(this will start working only when this change is merged I believe)~ 